### PR TITLE
add note on setting the default git editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Previously we examined how you can use git to save our work progress by making c
   - Remember you can share your screen to get help or demonstrate for your teammates.
 - Ask for help via Slack, if needed, so your instructor can know to jump in and assist
 
+## Before Getting Started
+
+Just to make sure that VS Code is set as the default editor for git commit messages, in the terminal execute this command:
+
+```bash
+$ git config --global core.editor "code --wait"
+```
+
 ### Set Up the Repository
 
 We will form into teams of 2-3 students. **One** partner will fork and clone this repository.


### PR DESCRIPTION
Just following up with you to add a note at the beginning to have them set vscode as the default editor before starting.  *Most* students should already have this from installfest, but not everyone does the automated setup. 